### PR TITLE
Document pm2 ecosystem config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,30 @@ cd /opt/tgapi
 # Установить npm-зависимости (если не сделали автоматически)
 npm ci --production
 
-# Запустить приложение через pm2
+# Убедитесь, что рядом лежит ecosystem.config.cjs (устанавливается скриптом) и запустите через pm2
+# Если файла нет, создайте его вручную:
+cat <<'CONFIG' > ecosystem.config.cjs
+/**
+ * PM2 ecosystem configuration for the tgapi service.
+ */
+module.exports = {
+  apps: [
+    {
+      name: 'tgapi',
+      cwd: '/opt/tgapi',
+      script: 'src/server.js',
+      env: {
+        NODE_ENV: 'development',
+        PORT: '3000',
+      },
+      env_production: {
+        NODE_ENV: 'production',
+        PORT: '3000',
+      },
+    },
+  ],
+};
+CONFIG
 pm2 start ecosystem.config.cjs --env production && pm2 save
 
 # Запустить локальный терминальный QR-визард (если QR не отображается в текущем терминале)

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,21 @@
+/**
+ * PM2 ecosystem configuration for the tgapi service.
+ * Keep this in sync with install_tgapi.sh so automated installs ship the same setup.
+ */
+module.exports = {
+  apps: [
+    {
+      name: 'tgapi',
+      cwd: '/opt/tgapi',
+      script: 'src/server.js',
+      env: {
+        NODE_ENV: 'development',
+        PORT: '3000',
+      },
+      env_production: {
+        NODE_ENV: 'production',
+        PORT: '3000',
+      },
+    },
+  ],
+};

--- a/install_tgapi.sh
+++ b/install_tgapi.sh
@@ -33,10 +33,11 @@ npm i express cors dotenv telegram
 
 # fetch server.js & qr_wizard.sh from this repo
 curl -fsSL https://raw.githubusercontent.com/kalininlive/Userbot-TG-Websansay/main/src/server.js -o /opt/tgapi/src/server.js
+curl -fsSL https://raw.githubusercontent.com/kalininlive/Userbot-TG-Websansay/main/ecosystem.config.cjs -o /opt/tgapi/ecosystem.config.cjs
 curl -fsSL https://raw.githubusercontent.com/kalininlive/Userbot-TG-Websansay/main/qr_wizard.sh -o /opt/tgapi/qr_wizard.sh
 chmod +x /opt/tgapi/qr_wizard.sh
 
-pm2 start /opt/tgapi/src/server.js --name tgapi || pm2 restart tgapi --update-env
+pm2 start /opt/tgapi/ecosystem.config.cjs --env production || pm2 restart tgapi --update-env
 pm2 save
 
 API_TOKEN=$(grep '^API_TOKEN=' /opt/tgapi/.env | cut -d= -f2)


### PR DESCRIPTION
## Summary
- add documentation for manually creating the pm2 ecosystem config during fallback setup
- update the ecosystem config with context comments and stringified defaults for NODE_ENV and PORT

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5a440f40832483f1a7f90b54e332