### PR TITLE
Improve QR wizard resilience to API errors

### DIFF
--- a/qr_wizard.sh
+++ b/qr_wizard.sh
@@ -10,25 +10,71 @@ read -r -p "Введите name (имя аккаунта): " NAME
 command -v jq >/dev/null || { echo "jq не установлен"; exit 1; }
 command -v qrencode >/dev/null || { echo "qrencode не установлен"; exit 1; }
 
-resp="$(curl -s -X POST "$API/auth/qr/start" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"$NAME\",\"apiId\":$API_ID,\"apiHash\":\"$API_HASH\"}")"
-ok="$(echo "$resp" | jq -r '.ok // false')"; [ "$ok" = "true" ] || { echo "Ошибка старта: $resp"; exit 1; }
+if ! resp="$(curl -fsS -X POST "$API/auth/qr/start" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"$NAME\",\"apiId\":$API_ID,\"apiHash\":\"$API_HASH\"}" 2>&1)"; then
+  echo "Не удалось инициировать QR-авторизацию: $resp"
+  exit 1
+fi
+
+if ! printf '%s' "$resp" | jq empty >/dev/null 2>&1; then
+  echo "Сервер вернул некорректный ответ при старте авторизации: $resp"
+  exit 1
+fi
+
+if ! ok="$(printf '%s' "$resp" | jq -r '.ok // false' 2>/dev/null)"; then
+  echo "Не удалось обработать ответ сервера при старте авторизации: $resp"
+  exit 1
+fi
+
+[ "$ok" = "true" ] || { echo "Ошибка старта: $resp"; exit 1; }
 
 clear; printf '\033[?25l'
 trap 'printf "\033[?25h\n"; exit 0' INT TERM
+
+render_header() {
+  local status="$1"
+  printf '\033[H'
+  echo "API: $API"
+  echo "NAME: $NAME"
+  echo "TIME: $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "STAT: $status"
+  echo
+}
+
 prev=""; last=0; interval=15
 for _ in $(seq 1 600); do
-  json="$(curl -s -G "$API/auth/qr/status" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME")"
-  status="$(echo "$json" | jq -r '.status // "unknown"')"
-  # Extract QR login URL from either the new 'qr' field or the legacy 'login_url' field
-  url="$(echo "$json" | jq -r '.qr // .login_url // empty')"
-  printf '\033[H'
-  echo "API: $API"; echo "NAME: $NAME"; echo "TIME: $(date '+%Y-%m-%d %H:%M:%S')"; echo "STAT: $status"; echo
+  if ! json="$(curl -fsS -G "$API/auth/qr/status" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME" 2>&1)"; then
+    render_header "network-error"
+    echo "⚠️ Не удалось получить статус QR: $json"
+    sleep 5
+    continue
+  fi
+
+  if ! printf '%s' "$json" | jq empty >/dev/null 2>&1; then
+    render_header "invalid-response"
+    echo "⚠️ Сервер вернул некорректный JSON: $json"
+    sleep 5
+    continue
+  fi
+
+  status="$(printf '%s' "$json" | jq -r '.status // "unknown"')"
+  url="$(printf '%s' "$json" | jq -r '.qr // .login_url // empty')"
+
+  render_header "$status"
+
   if [ "$status" = "authorized" ]; then
-    echo "✅ Авторизовано."; printf '\033[?25h\n'
-    echo; echo "— /me:"; curl -s -G "$API/me" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME" | jq .
+    echo "✅ Авторизовано."
+    printf '\033[?25h\n'
+    echo
+    echo "— /me:"
+    curl -s -G "$API/me" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME" | jq .
     exit 0
   fi
-  if [ "$status" = "error" ]; then echo "⛔ $(echo "$json" | jq -r '.error // "error"')"; break; fi
+
+  if [ "$status" = "error" ]; then
+    echo "⛔ $(printf '%s' "$json" | jq -r '.error // "error"')"
+    break
+  fi
+
   now="$(date +%s)"
   if [ -n "$url" ] && [ "$url" != "null" ]; then
     if [ "$url" != "$prev" ] && [ $((now - last)) -ge $interval ]; then
@@ -41,6 +87,8 @@ for _ in $(seq 1 600); do
   else
     echo "… Ждём появления QR-токена"
   fi
+
   sleep 5
 done
 printf '\033[?25h\n'
+

--- a/qr_wizard_local.sh
+++ b/qr_wizard_local.sh
@@ -34,8 +34,21 @@ command -v jq >/dev/null || { echo "jq не установлен"; exit 1; }
 command -v qrencode >/dev/null || { echo "qrencode не установлен"; exit 1; }
 
 # Запуск процесса авторизации
-resp="$(curl -s -X POST "$API/auth/qr/start" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"$NAME\",\"apiId\":$API_ID,\"apiHash\":\"$API_HASH\"}")"
-ok="$(echo "$resp" | jq -r '.ok // false')"
+if ! resp="$(curl -fsS -X POST "$API/auth/qr/start" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"$NAME\",\"apiId\":$API_ID,\"apiHash\":\"$API_HASH\"}" 2>&1)"; then
+  echo "Не удалось инициировать QR-авторизацию: $resp"
+  exit 1
+fi
+
+if ! printf '%s' "$resp" | jq empty >/dev/null 2>&1; then
+  echo "Сервер вернул некорректный ответ при старте авторизации: $resp"
+  exit 1
+fi
+
+if ! ok="$(printf '%s' "$resp" | jq -r '.ok // false' 2>/dev/null)"; then
+  echo "Не удалось обработать ответ сервера при старте авторизации: $resp"
+  exit 1
+fi
+
 if [ "$ok" != "true" ]; then
   echo "Ошибка старта: $resp"
   exit 1
@@ -43,19 +56,37 @@ fi
 
 clear; printf '\033[?25l'
 trap 'printf "\033[?25h\n"; exit 0' INT TERM
-prev=""; last=0; interval=15
-while true; do
-  json="$(curl -s -G "$API/auth/qr/status" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME")"
-  status="$(echo "$json" | jq -r '.status // "unknown"')"
-  # Извлекаем qr‑ссылку (tg://login?token=...), имя поля зависит от версии API
-  url="$(echo "$json" | jq -r '.qr // .login_url // empty')"
 
+render_header() {
+  local status="$1"
   printf '\033[H'
   echo "API: $API"
   echo "NAME: $NAME"
   echo "TIME: $(date '+%Y-%m-%d %H:%M:%S')"
   echo "STAT: $status"
   echo
+}
+
+prev=""; last=0; interval=15
+while true; do
+  if ! json="$(curl -fsS -G "$API/auth/qr/status" -H "Authorization: Bearer $TOKEN" --data-urlencode "name=$NAME" 2>&1)"; then
+    render_header "network-error"
+    echo "⚠️ Не удалось получить статус QR: $json"
+    sleep 5
+    continue
+  fi
+
+  if ! printf '%s' "$json" | jq empty >/dev/null 2>&1; then
+    render_header "invalid-response"
+    echo "⚠️ Сервер вернул некорректный JSON: $json"
+    sleep 5
+    continue
+  fi
+
+  status="$(printf '%s' "$json" | jq -r '.status // "unknown"')"
+  url="$(printf '%s' "$json" | jq -r '.qr // .login_url // empty')"
+
+  render_header "$status"
 
   if [ "$status" = "authorized" ]; then
     echo "✅ Авторизовано."
@@ -67,7 +98,7 @@ while true; do
   fi
 
   if [ "$status" = "error" ]; then
-    echo "⛔ $(echo "$json" | jq -r '.error // "error"')"
+    echo "⛔ $(printf '%s' "$json" | jq -r '.error // "error"')"
     break
   fi
 
@@ -89,3 +120,4 @@ done
 
 printf '\033[?25h\n'
 exit 0
+


### PR DESCRIPTION
## Summary
- add explicit error handling to qr_wizard scripts when starting the QR session and validating responses
- make the polling loop resilient to transient API failures while keeping terminal output tidy

## Testing
- bash -n qr_wizard.sh
- bash -n qr_wizard_local.sh

------
https://chatgpt.com/codex/tasks/task_e_68da61e4a2b08324b8a2bda3c06d03b6